### PR TITLE
Use new API updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "libc"
-version = "0.2.113"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
+checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
 
 [[package]]
 name = "libloading"
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "polychat-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31648f9d1fea593b6bdd69abfdb4ce96ef7ace885f92f3d2958a45e209789489"
+checksum = "7eca13da74ede573ddf2d72c20db939adc835d787c14cf23ce5c8146fdb18f4c"
 dependencies = [
  "libloading",
  "polychat-plugin",
@@ -176,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "polychat-plugin"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb043d789586865423bf320ba6ad6832f4a82e5efe7bf0644a9e33048970729"
+checksum = "9e27406ecbda01b1377eaa0426a3f9824cf8a67128e6ac3d64d4b18671bdeb9e"
 dependencies = [
  "cbindgen",
  "libc",
@@ -228,18 +228,18 @@ checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "serde"
-version = "1.0.135"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf9235533494ea2ddcdb794665461814781c53f19d87b76e571a1c35acbad2b"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.135"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dcde03d87d4c973c04be249e7d8f0b35db1c848c487bd43032808e59dd8328d"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,8 @@ dependencies = [
 [[package]]
 name = "polychat-core"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31648f9d1fea593b6bdd69abfdb4ce96ef7ace885f92f3d2958a45e209789489"
 dependencies = [
  "libloading",
  "polychat-plugin",
@@ -175,6 +177,8 @@ dependencies = [
 [[package]]
 name = "polychat-plugin"
 version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb043d789586865423bf320ba6ad6832f4a82e5efe7bf0644a9e33048970729"
 dependencies = [
  "cbindgen",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,8 +167,6 @@ dependencies = [
 [[package]]
 name = "polychat-core"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31648f9d1fea593b6bdd69abfdb4ce96ef7ace885f92f3d2958a45e209789489"
 dependencies = [
  "libloading",
  "polychat-plugin",
@@ -177,8 +175,6 @@ dependencies = [
 [[package]]
 name = "polychat-plugin"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb043d789586865423bf320ba6ad6832f4a82e5efe7bf0644a9e33048970729"
 dependencies = [
  "cbindgen",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-polychat-core = "0.1.1"
+polychat-core = {path = "../polychat-core"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-polychat-core = {path = "../polychat-core"}
+polychat-core = "0.1.*"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use polychat_core::plugin::Plugin;
 
 fn main() {
     let plugin_path = env::args().nth(1).expect("Usage: ./polychat-basic <absolute path to library>");
-    let loaded_plugin = &mut Plugin::new("example", &plugin_path).expect("Could not load plugin");
+    let loaded_plugin = &mut Plugin::new(&plugin_path).expect("Could not load plugin");
 
     let acc = loaded_plugin.create_account();
     loaded_plugin.print(acc);

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ fn main() {
     let plugin_path = env::args().nth(1).expect("Usage: ./polychat-basic <absolute path to library>");
     let loaded_plugin = &mut Plugin::new("example", &plugin_path).expect("Could not load plugin");
 
-    let acc = loaded_plugin.create_account().expect("Could not create account for plugin");
-    loaded_plugin.print(acc).expect("Could not print account");
+    let acc = loaded_plugin.create_account();
+    loaded_plugin.print(acc);
+    loaded_plugin.delete_account(acc);
 }


### PR DESCRIPTION
This keeps this binary up to date with polychat-core's latest updates, and updates to use the new plugin structure setup.